### PR TITLE
A few changes to improve readout accuracy & clean code

### DIFF
--- a/pulseaudio.lua
+++ b/pulseaudio.lua
@@ -32,12 +32,12 @@ function pulseaudio:Create()
 	o.Mute = false   -- state of the mute flag of the default sink
 
 	-- retreive current state from Pulseaudio
-	pulseaudio.GetState(o)
+	pulseaudio.UpdateState(o)
 
 	return o
 end
 
-function pulseaudio:GetState()
+function pulseaudio:UpdateState()
 	local f = io.popen(cmd .. " dump")
 
 	-- if the cmd can't be found
@@ -70,12 +70,7 @@ function pulseaudio:GetState()
 		end
 	end
 
-	if m == "yes" then
-		self.Mute = true
-	else
-		self.Mute = false
-	end
-
+	self.Mute = m == "yes"
 
 	f:close()
 end
@@ -94,8 +89,8 @@ function pulseaudio:SetVolume(vol)
 	-- set…
 	io.popen(cmd .. " set-sink-volume " .. default_sink .. " " .. string.format("0x%x", vol))
 
-	-- …and update values.
-	self:GetState()
+	-- …and update values
+	self:UpdateState()
 end
 
 
@@ -108,7 +103,7 @@ function pulseaudio:ToggleMute()
 	end
 	
 	-- …and update values.
-	self:GetState()
+	self:UpdateState()
 end
 
 

--- a/widget.lua
+++ b/widget.lua
@@ -43,25 +43,30 @@ function pulseWidget.setColor(mute)
 	end
 end
 
-function pulseWidget.Update()
+local function _update()
 	pulseWidget:set_value(p.Volume)
 	pulseWidget.setColor(p.Mute)
 end
 
 function pulseWidget.Up()
 	p:SetVolume(p.Volume + pulseWidget.step)
-	pulseWidget.Update()
+	_update()
 end	
 
 function pulseWidget.Down()
 	p:SetVolume(p.Volume - pulseWidget.step)
-	pulseWidget.Update()
+	_update()
 end	
 
 
 function pulseWidget.ToggleMute()
 	p:ToggleMute()
-	pulseWidget.Update()
+	_update()
+end
+
+function pulseWidget.Update()
+	p:UpdateState()
+	 _update()
 end
 
 -- register mouse button actions
@@ -74,7 +79,6 @@ pulseWidget:buttons(awful.util.table.join(
 
 
 -- initialize
-pulseWidget.Update(false)
-pulseWidget.setColor(p.Mute)
+_update()
 
 return pulseWidget


### PR DESCRIPTION
- Rename pulseaudio:GetState to pulseaudio:UpdateState() to more
  accurately reflect its function of updating the state of the active
  object.
- Split up the widget's update function into _update and
  widget.Update(). _update updates the widget's value from the pulse
  handle's cache, while widget.Update() updates the cache first, making it
  functional for calling in a timer to respond to outside updates.
- Remove invalid f:close() call. Functions cannot be called on null
  tables.
