### PR TITLE
Fix show_text mode by using wibox.layout.stack

### DIFF
--- a/widget.lua
+++ b/widget.lua
@@ -52,28 +52,16 @@ local pulseBar = wibox.widget.progressbar()
 pulseBar.forced_width = width
 pulseBar.step = step
 
-local function make_stack(w1, w2)
-    local ret = wibox.widget.base.make_widget()
-
-    ret.fit = function(self, ...) return w1:fit(...) end
-    ret.draw = function(self, wibox, cr, width, height)
-        w1:draw(wibox, cr, width, height)
-        w2:draw(wibox, cr, width, height)
-    end
-
-    local update = function() ret:emit_signal("widget::updated") end
-    w1:connect_signal("widget::updated", update)
-    w2:connect_signal("widget::updated", update)
-
-    return ret
-end
-
 local pulseWidget
 local pulseText
 if show_text then
     pulseText = wibox.widget.textbox()
     pulseText:set_align("center")
-    pulseWidget = wibox.container.margin(make_stack(pulseBar, pulseText),
+    pulseWidget = wibox.container.margin(wibox.widget {
+                                              pulseBar,
+                                              pulseText,
+                                              layout = wibox.layout.stack
+                                            },
                                             margin_right, margin_left,
                                             margin_top, margin_bottom)
 else


### PR DESCRIPTION
If like me you had set `show_text = true` on line 29, the widget layout broke in the upgrade from Awesome 3.x to 4.1, with the widget taking up almost the entire width of the screen. This PR fixes show_text mode by using `wibox.layout.stack` instead of doing any custom widget stacking, and deletes the now-unused `make_stack()`.